### PR TITLE
Fix missing empleados app in Django settings

### DIFF
--- a/ERPModular/settings.py
+++ b/ERPModular/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'finanzas',
     'clientes',
     'interfaz',
+    'empleados',
 
 ]
 


### PR DESCRIPTION
## Summary
- include `empleados` in `INSTALLED_APPS`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687716ddaa80832eb433db4956bddc40